### PR TITLE
Fix the type in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ sudo xbps-install glibc-devel
 ## Installation
 
 ```bash
-git clone https://github.com/mitjafelician/xdgctl.git
+git clone https://github.com/mitjafelicijan/xdgctl.git
 cd xdgctl
 
 # Build


### PR DESCRIPTION
The installation section now contains the correct link of the repo which is:
`https://github.com/mitjafelicijan/xdgctl.git` instead of `https://github.com/mitjafelician/xdgctl.git`.

Closes #2 